### PR TITLE
[qtbase] Support VPN connection reset case in state change. JB#55889

### DIFF
--- a/src/network/access/qnetworkaccessmanager.cpp
+++ b/src/network/access/qnetworkaccessmanager.cpp
@@ -1666,9 +1666,6 @@ void QNetworkAccessManagerPrivate::_q_networkSessionStateChanged(QNetworkSession
 
     lastSessionState = state;
 
-    if (updateStateOnly)
-        return;
-
     if ((state == QNetworkSession::Disconnected) || (state == QNetworkSession::Connecting)) {
         Q_FOREACH (const QNetworkConfiguration &cfg, networkConfigurationManager.allConfigurations()) {
             if (cfg.state().testFlag(QNetworkConfiguration::Active)) {
@@ -1693,6 +1690,10 @@ void QNetworkAccessManagerPrivate::_q_networkSessionStateChanged(QNetworkSession
                 emit q->networkAccessibleChanged(networkAccessible);
             }
     }
+
+    if (updateStateOnly)
+        return;
+
     online = reallyOnline;
     if (online && (state != QNetworkSession::Connected && state != QNetworkSession::Roaming)) {
         _q_networkSessionClosed();


### PR DESCRIPTION
VPN connections may reset themselves back to connecting state when they
are doing an internal reset. This causes the network session state to go
from connected to connecting and then back to connected when the reset
succeeds, and to disconnect when the connection fails despite the reset.

Without the change a segfault is caused as a result of failing to
allocate new memory:
Thread 1 "lipstick" received signal SIGSEGV, Segmentation fault.
QByteArray::reallocData (this=this@entry=0x7fe44f9128, alloc=1, options=options@entry=...) at tools/qbytearray.cpp:1604
1604	{
(gdb) bt
0  0x0000007c20a07138 in QByteArray::reallocData(unsigned int, QFlags<QArrayData::AllocationOption>) (this=this@entry=0x7fe44f9128, alloc=1, options=options@entry=...)
    at tools/qbytearray.cpp:1604
1  0x0000007c20bc375c in QByteArray::reserve(int) (asize=0, this=0x7fe44f9128) at ../../include/QtCore/../../src/corelib/global/qflags.h:131
2  0x0000007c20bc375c in normalizeTypeInternal(char const*, char const*, bool, bool)
    (t=t@entry=0x7fe44f91a0 ")", e=e@entry=0x7fe44f91a0 ")", adjustConst=adjustConst@entry=true, fixScope=false)
    at ../../include/QtCore/5.6.3/QtCore/private/../../../../../src/corelib/kernel/qmetaobject_moc_p.h:92
3  0x0000007c20bc3ed0 in qNormalizeType(char*, int&, QByteArray&) (d=<optimized out>, d@entry=0x7fe44f91a0 ")", templdepth=@0x7fe44f9184: 0, result=...) at kernel/qmetaobject.cpp:1255
4  0x0000007c20bca05c in QMetaObject::normalizedSignature(char const*) (method=method@entry=0x7c20f47358 "2opened()") at kernel/qmetaobject.cpp:1317
5  0x0000007c20bea778 in QObject::disconnect(QObject const*, char const*, QObject const*, char const*)
    (sender=0x7bd8045c70, signal=signal@entry=0x7c20f47358 "2opened()", receiver=receiver@entry=0xe588930, method=method@entry=0x7c20f47338 "2networkSessionConnected()")
    at kernel/qobject.cpp:2911
6  0x0000007c20e858b8 in QNetworkAccessManagerPrivate::_q_networkSessionClosed() (this=this@entry=0xe5880a0) at access/qnetworkaccessmanager.cpp:1637
7  0x0000007c20e872f8 in QNetworkAccessManagerPrivate::_q_networkSessionStateChanged(QNetworkSession::State) (this=this@entry=0xe5880a0, state=QNetworkSession::Connecting)
    at access/qnetworkaccessmanager.cpp:1687
8  0x0000007c20e877e4 in QNetworkAccessManagerPrivate::createSession(QNetworkConfiguration const&) (this=this@entry=0xe5880a0, config=...)
    at ../../include/QtCore/../../src/corelib/tools/qsharedpointer_impl.h:306
9  0x0000007c20e87310 in QNetworkAccessManagerPrivate::_q_networkSessionStateChanged(QNetworkSession::State) (this=this@entry=0xe5880a0, state=QNetworkSession::Connecting)
    at access/qnetworkaccessmanager.cpp:1688
10 0x0000007c20e877e4 in QNetworkAccessManagerPrivate::createSession(QNetworkConfiguration const&) (this=this@entry=0xe5880a0, config=...)
    at ../../include/QtCore/../../src/corelib/tools/qsharedpointer_impl.h:306
11 0x0000007c20e87310 in QNetworkAccessManagerPrivate::_q_networkSessionStateChanged(QNetworkSession::State) (this=this@entry=0xe5880a0, state=QNetworkSession::Connecting)
    at access/qnetworkaccessmanager.cpp:1688

And the backtrace shown in lines 8-11 does over 15 000 iterations before
this segfault happens.

By allowing the network state change back from connected to connecting
this can be avoided by doing only a simple state change and quitting
afterwards. The availability of the network remains unchanged.