### PR TITLE
[qtbase] Protect QNetworkAccessManager on duplicated state changes. JB#57985

### DIFF
--- a/src/network/access/qnetworkaccessmanager.cpp
+++ b/src/network/access/qnetworkaccessmanager.cpp
@@ -1651,6 +1651,10 @@ void QNetworkAccessManagerPrivate::_q_networkSessionStateChanged(QNetworkSession
     Q_Q(QNetworkAccessManager);
     qCDebug(lcNetworkAccess) << "QNAM: network session state changed:" << state;
 
+    if (state == lastSessionState) {
+        return;
+    }
+
     bool reallyOnline = false;
     bool updateStateOnly = false;
     //Do not emit the networkSessionConnected signal here, except for roaming -> connected


### PR DESCRIPTION
Getting state change to connecting and calling createSession()
at the bottom of this method was itself calling back the method again
with connecting state and ending up looping endlessly.

The calls between these methods are suspicious to begin with.
Added on commit 1c2210b7b1e / QTBUG-49760 for Qt 5.6.1.

@rainemak @LaakkonenJussi 