### PR TITLE
[qconnmanengine] Suppress bearer type warning. Fixes JB#57601

### DIFF
--- a/src/plugins/bearer/connman/qconnmanengine.cpp
+++ b/src/plugins/bearer/connman/qconnmanengine.cpp
@@ -491,7 +491,7 @@ QNetworkConfiguration::BearerType QConnmanEngine::ofonoTechToBearerType(const QS
         } else if (currentTechnology == QLatin1String("lte")) {
             return QNetworkConfiguration::BearerLTE;
         } else {
-            qCWarning(qLcLibBearer) << "QConnmanEngine: Unable to translate the bearer type of the unknown network technology:" << currentTechnology;
+            qCDebug(qLcLibBearer) << "QConnmanEngine: Unable to translate the bearer type of the unknown network technology:" << currentTechnology;
         }
     } else {
         qCWarning(qLcLibBearer) << "QConnmanEngine: Attempted to query the bearer type of a cellular connection but Ofono isn't available";


### PR DESCRIPTION
By changing the logging level to debug, this commit suppresses
the following warning:
qt.qpa.bearer.connman: QConnmanEngine: Unable to translate the
bearer type of the unknown network technology: ""

Warning is the default logging level for "qt.qpa.bearer.connman".