### PR TITLE
[qconnmanengine] Do not trigger scan if tech is not powered. Fixes JB#51252

### DIFF
--- a/src/plugins/bearer/connman/qconnmanservice_linux.cpp
+++ b/src/plugins/bearer/connman/qconnmanservice_linux.cpp
@@ -494,6 +494,11 @@ QString QConnmanTechnologyInterface::type()
 
 void QConnmanTechnologyInterface::scan()
 {
+    if (!getProperty(QStringLiteral("Powered")).toBool()) {
+        qCDebug(qLcLibBearer) << "QConnmanTechnologyInterface::scan() technology not powered";
+        return;
+    }
+
     QDBusPendingReply<> reply = asyncCall(QLatin1String("Scan"));
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
     connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),


### PR DESCRIPTION
By changing the logging level to debug, this commit suppresses
the following warning:

qt.qpa.bearer.connman: QConnmanTechnologyInterface::scanReply()
"No carrier"

Warning is the default logging level for "qt.qpa.bearer.connman".

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>