### PR TITLE
[qtnetwork] Replace SSL verification error locks

### DIFF
--- a/src/network/ssl/qsslsocket_openssl_p.h
+++ b/src/network/ssl/qsslsocket_openssl_p.h
@@ -115,6 +115,10 @@ public:
 #if OPENSSL_VERSION_NUMBER >= 0x10001000L
     static int s_indexForSSLExtraData; // index used in SSL_get_ex_data to get the matching QSslSocketBackendPrivate
 #endif
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    static int s_indexForSSLErrorExtraData; // user data index used for attaching a list of errors to a SSL struct
+    static int s_indexForX509StoreErrorExtraData; // user data index used for attaching a list of errors to a X509_STORE
+#endif
 
     // Platform specific functions
     void startClientEncryption() Q_DECL_OVERRIDE;

--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp
+++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp
@@ -194,6 +194,8 @@ DEFINEFUNC(int, EC_GROUP_get_degree, const EC_GROUP* g, g, return 0, return)
 DEFINEFUNC(int, CRYPTO_num_locks, DUMMYARG, DUMMYARG, return 0, return)
 DEFINEFUNC(void, CRYPTO_set_locking_callback, void (*a)(int, int, const char *, int), a, return, DUMMYARG)
 DEFINEFUNC(void, CRYPTO_set_id_callback, unsigned long (*a)(), a, return, DUMMYARG)
+DEFINEFUNC3(int, CRYPTO_set_ex_data, CRYPTO_EX_DATA * r, r, int idx, idx, void * arg, arg, return 0, return);
+DEFINEFUNC2(void *, CRYPTO_get_ex_data, CRYPTO_EX_DATA * r, r, int idx, idx, return nullptr, return);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 DEFINEFUNC3(void, CRYPTO_free, void *str, str, const char *file, file, int line, line, return, DUMMYARG)
 #else
@@ -341,6 +343,7 @@ DEFINEFUNC(SSL_SESSION*, SSL_get_session, const SSL *ssl, ssl, return 0, return)
 DEFINEFUNC5(int, SSL_get_ex_new_index, long argl, argl, void *argp, argp, CRYPTO_EX_new *new_func, new_func, CRYPTO_EX_dup *dup_func, dup_func, CRYPTO_EX_free *free_func, free_func, return -1, return)
 DEFINEFUNC3(int, SSL_set_ex_data, SSL *ssl, ssl, int idx, idx, void *arg, arg, return 0, return)
 DEFINEFUNC2(void *, SSL_get_ex_data, const SSL *ssl, ssl, int idx, idx, return NULL, return)
+DEFINEFUNC(int, SSL_get_ex_data_X509_STORE_CTX_idx, void, DUMMYARG, return -1, return)
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x10001000L && !defined(OPENSSL_NO_PSK)
 DEFINEFUNC2(void, SSL_set_psk_client_callback, SSL* ssl, ssl, q_psk_client_callback_t callback, callback, return, DUMMYARG)
@@ -423,6 +426,10 @@ DEFINEFUNC(EVP_PKEY *, X509_PUBKEY_get, X509_PUBKEY *a, a, return 0, return)
 DEFINEFUNC(void, X509_STORE_free, X509_STORE *a, a, return, DUMMYARG)
 DEFINEFUNC(X509_STORE *, X509_STORE_new, DUMMYARG, DUMMYARG, return 0, return)
 DEFINEFUNC2(int, X509_STORE_add_cert, X509_STORE *a, a, X509 *b, b, return 0, return)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+DEFINEFUNC3(int, X509_STORE_set_ex_data, X509_STORE *d, d, int idx, idx, void *data, data, return -1, return)
+DEFINEFUNC2(void *, X509_STORE_get_ex_data, X509_STORE *d, d, int idx, idx, return nullptr, return)
+#endif
 DEFINEFUNC(void, X509_STORE_CTX_free, X509_STORE_CTX *a, a, return, DUMMYARG)
 DEFINEFUNC4(int, X509_STORE_CTX_init, X509_STORE_CTX *a, a, X509_STORE *b, b, X509 *c, c, STACK_OF(X509) *d, d, return -1, return)
 DEFINEFUNC2(int, X509_STORE_CTX_set_purpose, X509_STORE_CTX *a, a, int b, b, return -1, return)
@@ -430,7 +437,14 @@ DEFINEFUNC(int, X509_STORE_CTX_get_error, X509_STORE_CTX *a, a, return -1, retur
 DEFINEFUNC(int, X509_STORE_CTX_get_error_depth, X509_STORE_CTX *a, a, return -1, return)
 DEFINEFUNC(X509 *, X509_STORE_CTX_get_current_cert, X509_STORE_CTX *a, a, return 0, return)
 DEFINEFUNC(STACK_OF(X509) *, X509_STORE_CTX_get_chain, X509_STORE_CTX *a, a, return 0, return)
+DEFINEFUNC(X509_STORE *, X509_STORE_CTX_get0_store, X509_STORE_CTX *ctx, ctx, return nullptr, return)
 DEFINEFUNC(X509_STORE_CTX *, X509_STORE_CTX_new, DUMMYARG, DUMMYARG, return 0, return)
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+DEFINEFUNC3(int, X509_STORE_CTX_set_ex_data, X509_STORE_CTX *d, d, int idx, idx, void *data, data, return -1, return)
+DEFINEFUNC2(void *, X509_STORE_CTX_get_ex_data, X509_STORE_CTX *d, d, int idx, idx, return nullptr, return)
+#endif
+
 #ifdef SSLEAY_MACROS
 DEFINEFUNC2(int, i2d_DSAPrivateKey, const DSA *a, a, unsigned char **b, b, return -1, return)
 DEFINEFUNC2(int, i2d_RSAPrivateKey, const RSA *a, a, unsigned char **b, b, return -1, return)
@@ -975,6 +989,7 @@ bool q_resolveOpenSslSymbols()
     RESOLVEFUNC(SSL_get_ex_new_index)
     RESOLVEFUNC(SSL_set_ex_data)
     RESOLVEFUNC(SSL_get_ex_data)
+    RESOLVEFUNC(SSL_get_ex_data_X509_STORE_CTX_idx)
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x10001000L && !defined(OPENSSL_NO_PSK)
     RESOLVEFUNC(SSL_set_psk_client_callback)
@@ -1012,6 +1027,10 @@ bool q_resolveOpenSslSymbols()
     RESOLVEFUNC(X509_STORE_free)
     RESOLVEFUNC(X509_STORE_new)
     RESOLVEFUNC(X509_STORE_add_cert)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    RESOLVEFUNC(X509_STORE_get_ex_data)
+    RESOLVEFUNC(X509_STORE_set_ex_data)
+#endif
     RESOLVEFUNC(X509_STORE_CTX_free)
     RESOLVEFUNC(X509_STORE_CTX_init)
     RESOLVEFUNC(X509_STORE_CTX_new)
@@ -1020,6 +1039,11 @@ bool q_resolveOpenSslSymbols()
     RESOLVEFUNC(X509_STORE_CTX_get_error_depth)
     RESOLVEFUNC(X509_STORE_CTX_get_current_cert)
     RESOLVEFUNC(X509_STORE_CTX_get_chain)
+    RESOLVEFUNC(X509_STORE_CTX_get0_store)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    RESOLVEFUNC(X509_STORE_CTX_get_ex_data)
+    RESOLVEFUNC(X509_STORE_CTX_set_ex_data)
+#endif
     RESOLVEFUNC(X509_cmp)
 #ifndef SSLEAY_MACROS
     RESOLVEFUNC(X509_dup)

--- a/src/network/ssl/qsslsocket_openssl_symbols_p.h
+++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h
@@ -233,7 +233,12 @@ int q_EC_GROUP_get_degree(const EC_GROUP* g);
 int q_CRYPTO_num_locks();
 void q_CRYPTO_set_locking_callback(void (*a)(int, int, const char *, int));
 void q_CRYPTO_set_id_callback(unsigned long (*a)());
+int q_CRYPTO_set_ex_data(CRYPTO_EX_DATA *r, int idx, void *arg);
+void *q_CRYPTO_get_ex_data(CRYPTO_EX_DATA *r, int idx);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+int q_CRYPTO_get_ex_new_index(int class_index, long arg1, void *argp,
+                              CRYPTO_EX_new *new_func, CRYPTO_EX_dup *dup_func,
+                              CRYPTO_EX_free *free_func);
 void q_CRYPTO_free(void *a, const char *b, int c);
 #else
 void q_CRYPTO_free(void *a);
@@ -380,6 +385,7 @@ SSL_SESSION *q_SSL_get_session(const SSL *ssl);
 int q_SSL_get_ex_new_index(long argl, void *argp, CRYPTO_EX_new *new_func, CRYPTO_EX_dup *dup_func, CRYPTO_EX_free *free_func);
 int q_SSL_set_ex_data(SSL *ssl, int idx, void *arg);
 void *q_SSL_get_ex_data(const SSL *ssl, int idx);
+int q_SSL_get_ex_data_X509_STORE_CTX_idx();
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x10001000L && !defined(OPENSSL_NO_PSK)
 typedef unsigned int (*q_psk_client_callback_t)(SSL *ssl, const char *hint, char *identity, unsigned int max_identity_len, unsigned char *psk, unsigned int max_psk_len);
@@ -467,6 +473,12 @@ EVP_PKEY *q_X509_PUBKEY_get(X509_PUBKEY *a);
 void q_X509_STORE_free(X509_STORE *store);
 X509_STORE *q_X509_STORE_new();
 int q_X509_STORE_add_cert(X509_STORE *ctx, X509 *x);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+int q_X509_STORE_set_ex_data(X509_STORE *d, int idx, void *data);
+void *q_X509_STORE_get_ex_data(X509_STORE *d, int idx);
+#endif
+
 void q_X509_STORE_CTX_free(X509_STORE_CTX *storeCtx);
 int q_X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
                           X509 *x509, STACK_OF(X509) *chain);
@@ -476,6 +488,12 @@ int q_X509_STORE_CTX_get_error(X509_STORE_CTX *ctx);
 int q_X509_STORE_CTX_get_error_depth(X509_STORE_CTX *ctx);
 X509 *q_X509_STORE_CTX_get_current_cert(X509_STORE_CTX *ctx);
 STACK_OF(X509) *q_X509_STORE_CTX_get_chain(X509_STORE_CTX *ctx);
+X509_STORE *q_X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+int q_X509_STORE_CTX_set_ex_data(X509_STORE_CTX *d, int idx, void *data);
+void *q_X509_STORE_CTX_get_ex_data(X509_STORE_CTX *d, int idx);
+#endif
 
 // Diffie-Hellman support
 DH *q_DH_new();


### PR DESCRIPTION
This pull request should solve [QTBUG-76157](https://bugreports.qt.io/browse/QTBUG-76157) by removing the mutex-based error list and instead attaching the error list to either the X509_STORE or SSL struct as `ex_data`.

I couldn't get the Qt unit tests working, but I have tested this on my device [with a small application that I wrote for connecting with servers with known bad SSL certificates](https://github.com/HenkKalkwater/harbour-badssl) and it seems to work as before. 

Additionally, my own app Sailfin, does no longer freeze when connecting over HTTPS, so it does solve the problem for me.

I only have tested this on Sailfish 4.4.0.68. I assumed keeping support for older OpenSSL versions than 1.1.0 wasn't necessary, therefore building with older versions than 1.1.0 may fail. Please let me know if that would be an issue.

Related forum topic: https://forum.sailfishos.org/t/possibility-of-backporting-qt-bug-fixes/11424