### PR TITLE
Add option to evdev mouse driver to allow input to be rotated

### DIFF
--- a/src/platformsupport/input/evdevmouse/qevdevmousemanager.cpp
+++ b/src/platformsupport/input/evdevmouse/qevdevmousemanager.cpp
@@ -48,7 +48,7 @@ QT_BEGIN_NAMESPACE
 Q_DECLARE_LOGGING_CATEGORY(qLcEvdevMouse)
 
 QEvdevMouseManager::QEvdevMouseManager(const QString &key, const QString &specification, QObject *parent)
-    : QObject(parent), m_x(0), m_y(0), m_xoffset(0), m_yoffset(0)
+    : QObject(parent), m_x(0), m_y(0), m_xoffset(0), m_yoffset(0), m_rotate(0)
 {
     Q_UNUSED(key);
 
@@ -69,6 +69,11 @@ QEvdevMouseManager::QEvdevMouseManager(const QString &key, const QString &specif
             m_xoffset = arg.mid(8).toInt();
         } else if (arg.startsWith(QLatin1String("yoffset="))) {
             m_yoffset = arg.mid(8).toInt();
+        } else if (arg.startsWith(QLatin1String("rotate="))) {
+            int rotate = arg.mid(7).toInt();
+            if (rotate == 90 || rotate == 180 || rotate == 270) {
+                m_rotate = rotate;
+            }
         }
     }
 
@@ -124,8 +129,23 @@ void QEvdevMouseManager::handleMouseEvent(int x, int y, bool abs, Qt::MouseButto
 {
     // update current absolute coordinates
     if (!abs) {
-        m_x += x;
-        m_y += y;
+        switch (m_rotate) {
+            case 90:
+                m_x += y;
+                m_y += -x;
+                break;
+            case 180:
+                m_x += -x;
+                m_y += -y;
+                break;
+            case 270:
+                m_x += -y;
+                m_y += +x;
+                break;
+            default:
+                m_x += x;
+                m_y += y;
+        }
     } else {
         m_x = x;
         m_y = y;

--- a/src/platformsupport/input/evdevmouse/qevdevmousemanager_p.h
+++ b/src/platformsupport/input/evdevmouse/qevdevmousemanager_p.h
@@ -81,6 +81,7 @@ private:
     int m_y;
     int m_xoffset;
     int m_yoffset;
+    int m_rotate;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
Not a real fix, as lipstick should probably rotate the input, however works in the case of a tablet docked into a keyboard in landscape with touchpad, where the input needs rotated by 90degrees.